### PR TITLE
ci: misc fixes

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -27,4 +27,3 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          flags: "--deep"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,15 +12,15 @@ jobs:
       # Install latest Terraform manually as Docker-based GitHub Actions are
       # slow due to lack of caching.
       - name: install terraform
-        working-directory: ./terraform
         run: |
           curl -LO https://raw.githubusercontent.com/robertpeteuil/terraform-installer/f4f46c459bd75971a843373a2aa349f728534230/terraform-install.sh
           chmod +x terraform-install.sh
           ./terraform-install.sh -a -i 1.0.5
 
-      - name: terraform init
+      - name: terraform fmt
+        working-directory: ./terraform
         run: |
-          terraform init
+          terraform fmt
 
       - name: tflint
         uses: reviewdog/action-tflint@master


### PR DESCRIPTION
This PR replaces init with fmt, runs it in the `terraform/` directory, and drops the tflint flag.